### PR TITLE
Fix and test duplicate records from the mobile side

### DIFF
--- a/app/helpers/Observation.js
+++ b/app/helpers/Observation.js
@@ -26,12 +26,12 @@ class Observation {
       throw new Error('User not signed in')
     }
 
+    let realmObservation = realm.objects('Submission').filtered(`id == ${observation.id}`)[0]
     // Don't sync already synced record
-    if (observation.synced) {
+    if (realmObservation.synced || realmObservation.serverID !== -1) {
       return this.update(observation, callback)
     }
 
-    let realmObservation = realm.objects('Submission').filtered(`id == ${observation.id}`)[0]
     let form             = this._setUpForm(observation)
     let response         = null
     try {

--- a/app/helpers/Observation.js
+++ b/app/helpers/Observation.js
@@ -28,14 +28,13 @@ class Observation {
 
     // Don't sync already synced record
     if (observation.synced) {
-      return
+      return this.update(observation, callback)
     }
 
     let realmObservation = realm.objects('Submission').filtered(`id == ${observation.id}`)[0]
     let form             = this._setUpForm(observation)
     let response         = null
     try {
-      console.log('HERE', observation.serverID)
       let id
       if (realmObservation.serverID === -1) {
         response = await axios.post('/observations', form)
@@ -43,11 +42,15 @@ class Observation {
       } else {
         id = observation.serverID
       }
+
+      realm.write(() => {
+        realmObservation.serverID = id
+      })
+
       await this.uploadImages(observation, id, callback)
 
       realm.write(() => {
         realmObservation.synced   = true
-        realmObservation.serverID = id
       })
 
       return response


### PR DESCRIPTION
This PR fixes the duplication issue #402. The implemented solution allows the app save the server id once the minimal amount of data has been sent. The images are then lazy uploaded one by one. If the images fail to upload due to internet connectivity issues, the app notes that and requests an update the next time around instead of creating a new observation.