### PR TITLE
iOS navigation

### DIFF
--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -39,17 +39,22 @@ export default class Header extends Component {
 
   getLeftIcon = () => {
     if (!this.props.showLeftIcon) {
-      return
+      return <View style={[style.touchable, {width: 50}]}/>
     }
 
-    if (this.props.initial) {
+    if (this.props.initial && Platform.OS !== 'android') {
+      return <View style={[style.touchable, {width: 50}]}/>
+    }
+
+    if (this.props.initial && Platform.OS === 'android') {
       return (
-        <TouchableHighlight style={[style.touchable, {paddingLeft: 10}]} onPress={this.onMenuPress}
+        <TouchableHighlight style={[style.touchable, {paddingLeft: 10}]}
+                            onPress={this.onMenuPress}
                             underlayColor={Colors.primary}>
           <Icon name={this.state.menuIcon} style={{fontSize: 25}} color="#fff"/>
         </TouchableHighlight>
       )
-    } else {
+    } else if (!this.props.initial) {
       return (
         <TouchableHighlight style={style.touchable} onPress={this.back}
                             underlayColor={Colors.primary}>
@@ -60,11 +65,12 @@ export default class Header extends Component {
   }
 
   getRightIcon = () => {
+    let icon    = (<View style={{width: 50, height: 30}}/>)
+
     if (!this.props.showRightIcon) {
-      return
+      return icon
     }
 
-    let icon    = (<Icon name="map-marker-multiple" size={23} color="#fff"/>)
     let onPress = this.navigateToMap
 
     if (this.props.rightIcon !== null) {
@@ -94,14 +100,19 @@ export default class Header extends Component {
   }
 
   render() {
+    let alignItems = 'center'
+    if (Platform.OS === 'android') {
+      alignItems = (this.props.showLeftIcon && !this.props.initial ? 'flex-start' : 'center')
+    }
+
     return (
       <View style={[style.wrapper, {...new Elevation(this.props.elevation)}]}>
         {this.getLeftIcon()}
 
         <View
           style={[style.titleContainer, {
-              alignItems: this.props.showLeftIcon ? 'flex-start' : 'center'
-            }]}>
+            alignItems
+          }]}>
           <Text style={[style.text, style.title]} numberOfLines={1}>{this.props.title}</Text>
         </View>
 

--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -102,7 +102,7 @@ export default class Header extends Component {
   render() {
     let alignItems = 'center'
     if (Platform.OS === 'android') {
-      alignItems = (this.props.showLeftIcon && !this.props.initial ? 'flex-start' : 'center')
+      alignItems = (this.props.showLeftIcon ? 'flex-start' : 'center')
     }
 
     return (

--- a/app/routes/MoreStackNavigator.js
+++ b/app/routes/MoreStackNavigator.js
@@ -1,0 +1,51 @@
+import {createStackNavigator} from 'react-navigation'
+import IntermediateAccountScreen from '../screens/IntermediateAccountScreen'
+import IOSMoreScreen from '../screens/IOSMoreScreen'
+import AboutScreen from '../screens/AboutScreen'
+import HealthSafetyScreen from '../screens/HealthSafetyScreen'
+import PrivacyPolicyScreen from '../screens/PrivacyPolicySreen'
+import LoginScreen from '../screens/LoginScreen'
+import RegistrationScreen from '../screens/RegisterationScreen'
+
+const Nav = new createStackNavigator({
+  More         : {
+    screen: IOSMoreScreen
+  },
+  Account      : {
+    screen: IntermediateAccountScreen
+  },
+  About        : {
+    screen: AboutScreen
+  },
+  HealthSafety : {
+    screen: HealthSafetyScreen
+  },
+  PrivacyPolicy: {
+    screen: PrivacyPolicyScreen
+  },
+  Login        : {
+    screen: LoginScreen
+  },
+  Register     : {
+    screen: RegistrationScreen
+  }
+}, {
+  initialRouteName: 'More',
+  headerMode      : 'none'
+})
+
+Nav.navigationOptions = ({navigation}) => {
+  let drawerLockMode = 'unlocked'
+  let tabBarVisible  = true
+  if (navigation.state.index > 0) {
+    drawerLockMode = 'locked-closed'
+    tabBarVisible  = false
+  }
+
+  return {
+    drawerLockMode,
+    tabBarVisible
+  }
+}
+
+export default Nav

--- a/app/routes/Navigator.js
+++ b/app/routes/Navigator.js
@@ -272,21 +272,21 @@ export default class Navigator extends Component {
           ...(this.navigationOptions('Observe', 'md-aperture', 25))
         }
       },
-      // Show AccountScreen if user is logged in
-      ...(this.state.loggedIn ? {
-        Account: {
-          screen           : IntermediateAccountScreen,
-          navigationOptions: {
-            ...(this.navigationOptions('My Account', 'md-settings', 25))
-          }
-        }
-      } : null),
       ObservationsNavigator: {
         screen           : ObservationsNavigator,
         navigationOptions: {
           ...(this.navigationOptions('My Observations', 'ios-leaf', 25))
         }
       },
+      // Show AccountScreen if user is logged in
+      ...(this.state.loggedIn ? {
+        Account: {
+          screen           : IntermediateAccountScreen,
+          navigationOptions: {
+            ...(this.navigationOptions('Account Settings', 'md-settings', 25))
+          }
+        }
+      } : null),
       ...(this.sharedRoutes())
     }, {
       initialRouteName: 'Landing',

--- a/app/routes/Navigator.js
+++ b/app/routes/Navigator.js
@@ -7,27 +7,24 @@ import {
   DeviceEventEmitter
 } from 'react-native'
 import {
-  createStackNavigator,
   createBottomTabNavigator,
   createDrawerNavigator,
   DrawerItems
 } from 'react-navigation'
-import LandingScreen from '../screens/LandingScreen'
 import MapScreen from '../screens/MapScreen'
-import CameraScreen from '../screens/CameraScreen'
-import SubmittedScreen from '../screens/SubmittedScreen'
 import AboutScreen from '../screens/AboutScreen'
 import PrivacyPolicyScreen from '../screens/PrivacyPolicySreen'
 import HealthSafetyScreen from '../screens/HealthSafetyScreen'
 import LoginScreen from '../screens/LoginScreen'
 import RegistrationScreen from '../screens/RegisterationScreen'
-import TreeScreen from '../screens/TreeScreen'
 import Icon from 'react-native-vector-icons/Ionicons'
 import Colors from '../helpers/Colors'
 import IntermediateAccountScreen from '../screens/IntermediateAccountScreen'
 import ObservationsNavigator from './ObservationsNavigator'
 import User from '../db/User'
 import {ifIphoneX} from 'react-native-iphone-x-helper'
+import MoreStackNavigator from './MoreStackNavigator'
+import ObserveStackNavigator from './ObserveStackNavigator'
 
 /**
  * Implementation of react-navigation.
@@ -62,88 +59,37 @@ export default class Navigator extends Component {
   }
 
   /**
-   * The observe navigation stack. contains the landing page and all screens
-   * to submit an observation.
-   *
-   * @return {*}
-   */
-  observationStack() {
-    let nav = new createStackNavigator({
-      Landing  : {
-        screen           : LandingScreen,
-        navigationOptions: {
-          ...(this.navigationOptions('My Observations', 'md-home', 25))
-        }
-      },
-      Tree     : {
-        screen           : TreeScreen,
-        navigationOptions: {
-          gesturesEnabled: false,
-          drawerLockMode : 'locked-closed'
-        }
-      },
-      Camera   : {
-        screen           : CameraScreen,
-        navigationOptions: {
-          gesturesEnabled: false,
-          drawerLockMode : 'locked-closed'
-        }
-      },
-      Submitted: {
-        screen           : SubmittedScreen,
-        navigationOptions: {
-          gesturesEnabled: false,
-          drawerLockMode : 'locked-closed'
-        }
-      }
-    }, {
-      initialRouteName: 'Landing',
-      headerMode      : 'none'
-    })
-
-    nav.navigationOptions = ({navigation}) => {
-      let drawerLockMode = 'unlocked'
-      if (navigation.state.index > 0) {
-        drawerLockMode = 'locked-closed'
-      }
-
-      return {
-        drawerLockMode
-      }
-    }
-
-    return nav
-  }
-
-  /**
    * IOS Bottom Tabs.
    *
    * @return {*}
    */
   tabs() {
     return new createBottomTabNavigator({
-      Landing              : {
-        screen           : this.observationStack(),
+      Landing: {
+        screen           : ObserveStackNavigator,
         navigationOptions: {
           ...(this.navigationOptions('Observe', 'md-aperture'))
         }
       },
+
       ObservationsNavigator: {
         screen           : ObservationsNavigator,
         navigationOptions: {
           ...(this.navigationOptions('Observations', 'ios-leaf'))
         }
       },
-      Map                  : {
+
+      Map: {
         screen           : MapScreen,
         navigationOptions: {
           ...(this.navigationOptions('Map', 'md-map'))
         }
       },
-      Account              : {
-        screen           : IntermediateAccountScreen,
+
+      More: {
+        screen           : MoreStackNavigator,
         navigationOptions: {
-          ...(this.navigationOptions('Settings', 'md-settings'))
+          ...(this.navigationOptions('More', 'ios-more'))
         }
       }
     }, {
@@ -308,18 +254,7 @@ export default class Navigator extends Component {
    * @return {{XML}}
    */
   ios() {
-    const Nav = new createDrawerNavigator({
-      Landing: {
-        screen           : this.tabs(),
-        navigationOptions: {
-          ...(this.navigationOptions('Home', 'md-home', 25))
-        }
-      },
-      ...(this.sharedRoutes())
-    }, {
-      initialRouteName: 'Landing',
-      ...(this.drawerOptions())
-    })
+    const Nav = this.tabs()
 
     return (<Nav/>)
   }
@@ -332,7 +267,7 @@ export default class Navigator extends Component {
   android() {
     const Nav = new createDrawerNavigator({
       Landing              : {
-        screen           : this.observationStack(),
+        screen           : ObserveStackNavigator,
         navigationOptions: {
           ...(this.navigationOptions('Observe', 'md-aperture', 25))
         }
@@ -361,21 +296,8 @@ export default class Navigator extends Component {
     return (<Nav/>)
   }
 
-  /**
-   * Main method to create the navigator.
-   *
-   * @return {{XML}}
-   */
-  create() {
-    if (Platform.OS === 'android') {
-      return this.android()
-    } else {
-      return this.ios()
-    }
-  }
-
   render() {
-    return this.android()
+    return Platform.select({android: this.android(), ios: this.ios()})
   }
 }
 

--- a/app/routes/ObservationsNavigator.js
+++ b/app/routes/ObservationsNavigator.js
@@ -11,11 +11,26 @@ const Nav = new createStackNavigator({
   Observation : {
     screen           : ObservationScreen,
     navigationOptions: {
-      drawerLockMode: 'locked-closed'
+      drawerLockMode: 'locked-closed',
+      tabBarVisible: false
     }
   }
 }, {
   headerMode: 'none'
 })
+
+Nav.navigationOptions = ({navigation}) => {
+  let drawerLockMode = 'unlocked'
+  let tabBarVisible  = true
+  if (navigation.state.index > 0) {
+    drawerLockMode = 'locked-closed'
+    tabBarVisible  = false
+  }
+
+  return {
+    drawerLockMode,
+    tabBarVisible
+  }
+}
 
 export default Nav

--- a/app/routes/ObserveStackNavigator.js
+++ b/app/routes/ObserveStackNavigator.js
@@ -1,0 +1,70 @@
+import {createStackNavigator} from 'react-navigation'
+import LandingScreen from '../screens/LandingScreen'
+import SubmittedScreen from '../screens/SubmittedScreen'
+import CameraScreen from '../screens/CameraScreen'
+import TreeScreen from '../screens/TreeScreen'
+import Icon from 'react-native-vector-icons/Ionicons'
+
+function navigationOptions(label, icon, size) {
+  if (typeof size === 'undefined') {
+    size = 30
+  }
+
+  const renderedIcon = ({tintColor}) => <Icon name={icon} color={tintColor} size={size}/>
+
+  return {
+    drawerLabel: label,
+    drawerIcon : renderedIcon,
+    tabBarLabel: label,
+    tabBarIcon : renderedIcon
+  }
+}
+
+let Nav = new createStackNavigator({
+  Landing  : {
+    screen           : LandingScreen,
+    navigationOptions: {
+      ...(navigationOptions('My Observations', 'md-home', 25))
+    }
+  },
+  Tree     : {
+    screen           : TreeScreen,
+    navigationOptions: {
+      gesturesEnabled: false,
+      drawerLockMode : 'locked-closed'
+    }
+  },
+  Camera   : {
+    screen           : CameraScreen,
+    navigationOptions: {
+      gesturesEnabled: false,
+      drawerLockMode : 'locked-closed'
+    }
+  },
+  Submitted: {
+    screen           : SubmittedScreen,
+    navigationOptions: {
+      gesturesEnabled: false,
+      drawerLockMode : 'locked-closed'
+    }
+  }
+}, {
+  initialRouteName: 'Landing',
+  headerMode      : 'none'
+})
+
+Nav.navigationOptions = ({navigation}) => {
+  let drawerLockMode = 'unlocked'
+  let tabBarVisible  = true
+  if (navigation.state.index > 0) {
+    drawerLockMode = 'locked-closed'
+    tabBarVisible  = false
+  }
+
+  return {
+    drawerLockMode,
+    tabBarVisible
+  }
+}
+
+export default Nav

--- a/app/screens/AboutScreen.js
+++ b/app/screens/AboutScreen.js
@@ -1,12 +1,12 @@
 import React from 'react'
 import Screen from './Screen'
 import PropTypes from 'prop-types'
-import {View, ScrollView, StyleSheet, Text, BackHandler} from 'react-native'
+import {View, ScrollView, StyleSheet, Text, BackHandler, Platform} from 'react-native'
 import Header from '../components/Header'
 import Elevation from '../helpers/Elevation'
 import Atext from '../components/Atext'
 import PackageJSON from '../../package.json'
-
+const isAndroid = Platform.OS === 'android'
 export default class AboutScreen extends Screen {
   static navigationOptions = {
     tabBarVisible: false
@@ -28,7 +28,7 @@ export default class AboutScreen extends Screen {
           title="About Us"
           navigator={this.navigator}
           elevation={2}
-          initial={true}
+          initial={isAndroid}
           onMenuPress={() => this.navigator.toggleDrawer()}
         />
         <ScrollView style={styles.scrollView}>

--- a/app/screens/AccountScreen.js
+++ b/app/screens/AccountScreen.js
@@ -536,16 +536,18 @@ export default class AccountScreen extends Screen {
               <Text style={styles.buttonText}>Update</Text>
             </TouchableOpacity>
           </View>
-          <View style={styles.column}>
-            <TouchableOpacity
-              style={[styles.button, styles.buttonLink]}
-              onPress={() => {
-                this.navigator.goBack()
-              }}
-            >
-              <Text style={[styles.buttonText, styles.buttonLinkText]}>Cancel</Text>
-            </TouchableOpacity>
-          </View>
+          {isAndroid ? null :
+            <View style={styles.column}>
+              <TouchableOpacity
+                style={[styles.button, styles.buttonLink]}
+                onPress={() => {
+                  this.navigator.goBack(null)
+                }}
+              >
+                <Text style={[styles.buttonText, styles.buttonLinkText]}>Cancel</Text>
+              </TouchableOpacity>
+            </View>
+          }
         </View>
 
         <SnackBar ref="snackbar" noticeText={this.state.snackMessage}/>

--- a/app/screens/AccountScreen.js
+++ b/app/screens/AccountScreen.js
@@ -1,7 +1,17 @@
 import React from 'react'
 import Screen from './Screen'
 import PropTypes from 'prop-types'
-import {View, StyleSheet, Text, TextInput, TouchableOpacity, BackHandler, DeviceEventEmitter, Alert} from 'react-native'
+import {
+  View,
+  StyleSheet,
+  Platform,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  BackHandler,
+  DeviceEventEmitter,
+  Alert
+} from 'react-native'
 import Header from '../components/Header'
 import Elevation from '../helpers/Elevation'
 import Colors from '../helpers/Colors'
@@ -13,6 +23,8 @@ import Spinner from '../components/Spinner'
 import DateModal from '../components/DateModal'
 import {KeyboardAwareScrollView} from 'react-native-keyboard-aware-scroll-view'
 import User from '../db/User'
+
+const isAndroid = Platform.OS === 'android'
 
 export default class AccountScreen extends Screen {
   constructor(props) {
@@ -60,7 +72,7 @@ export default class AccountScreen extends Screen {
       return true
     })
 
-    this.events    = [
+    this.events = [
       DeviceEventEmitter.addListener('userLoggedOut', this.props.onLogout)
     ]
 
@@ -310,7 +322,7 @@ export default class AccountScreen extends Screen {
                 navigator={this.navigator}
                 elevation={4}
                 showRightIcon={false}
-                initial={true}
+                initial={isAndroid}
                 onMenuPress={() => this.navigator.toggleDrawer()}
         />
         <KeyboardAwareScrollView showsVerticalScrollIndicator={false}>
@@ -421,31 +433,31 @@ export default class AccountScreen extends Screen {
 
             {/*<Text style={styles.title}>AUTO SYNCHRONIZE</Text>*/}
             {/*<View style={styles.card}>*/}
-              {/*<PickerModal*/}
-                {/*style={[styles.formGroup, styles.noBorder]}*/}
-                {/*onSelect={(auto_sync) => this.setState({*/}
-                  {/*auto_sync  : auto_sync === 'Yes' ? true : false,*/}
-                  {/*userChanges: true*/}
-                {/*})}*/}
-                {/*initialSelect={this.user.auto_sync ? 'Yes' : 'No'}*/}
-                {/*choices={['Yes', 'No']}*/}
-                {/*header="Auto sync allows TreeSnap to upload observations as soon as you reach a WiFi enabled area. Would you like to activate auto sync?"*/}
-              {/*>*/}
-                {/*<View style={styles.row}>*/}
-                  {/*<Text style={styles.label}>Activated</Text>*/}
-                  {/*<TextInput*/}
-                    {/*style={styles.textField}*/}
-                    {/*autoCapitalize={'words'}*/}
-                    {/*placeholder={'No'}*/}
-                    {/*placeholderTextColor="#aaa"*/}
-                    {/*returnKeyType={'done'}*/}
-                    {/*value={this.user.auto_sync ? 'Yes' : 'No'}*/}
-                    {/*underlineColorAndroid="transparent"*/}
-                    {/*editable={false}*/}
-                    {/*readOnly={true}*/}
-                  {/*/>*/}
-                {/*</View>*/}
-              {/*</PickerModal>*/}
+            {/*<PickerModal*/}
+            {/*style={[styles.formGroup, styles.noBorder]}*/}
+            {/*onSelect={(auto_sync) => this.setState({*/}
+            {/*auto_sync  : auto_sync === 'Yes' ? true : false,*/}
+            {/*userChanges: true*/}
+            {/*})}*/}
+            {/*initialSelect={this.user.auto_sync ? 'Yes' : 'No'}*/}
+            {/*choices={['Yes', 'No']}*/}
+            {/*header="Auto sync allows TreeSnap to upload observations as soon as you reach a WiFi enabled area. Would you like to activate auto sync?"*/}
+            {/*>*/}
+            {/*<View style={styles.row}>*/}
+            {/*<Text style={styles.label}>Activated</Text>*/}
+            {/*<TextInput*/}
+            {/*style={styles.textField}*/}
+            {/*autoCapitalize={'words'}*/}
+            {/*placeholder={'No'}*/}
+            {/*placeholderTextColor="#aaa"*/}
+            {/*returnKeyType={'done'}*/}
+            {/*value={this.user.auto_sync ? 'Yes' : 'No'}*/}
+            {/*underlineColorAndroid="transparent"*/}
+            {/*editable={false}*/}
+            {/*readOnly={true}*/}
+            {/*/>*/}
+            {/*</View>*/}
+            {/*</PickerModal>*/}
             {/*</View>*/}
 
             <Text style={styles.title}>PASSWORD</Text>

--- a/app/screens/HealthSafetyScreen.js
+++ b/app/screens/HealthSafetyScreen.js
@@ -6,10 +6,13 @@ import {
   ScrollView,
   StyleSheet,
   Text,
-  BackHandler
+  BackHandler,
+Platform
 } from 'react-native'
 import Header from '../components/Header'
 import Elevation from '../helpers/Elevation'
+
+const isAndroid = Platform.OS === 'android'
 
 export default class HealthSafetyScreen extends Screen {
   static navigationOptions = {
@@ -31,7 +34,7 @@ export default class HealthSafetyScreen extends Screen {
         <Header title="Health and Safety"
                 navigator={this.navigator}
                 elevation={2}
-                initial={true}
+                initial={isAndroid}
                 onMenuPress={() => this.navigator.toggleDrawer()}/>
         <ScrollView style={styles.scrollView}>
 

--- a/app/screens/IOSMoreScreen.js
+++ b/app/screens/IOSMoreScreen.js
@@ -166,7 +166,7 @@ const styles = StyleSheet.create({
     flexDirection    : 'row',
     alignItems       : 'center',
     justifyContent   : 'space-between',
-    height           : 40,
+    height           : 50,
     borderBottomWidth: 1,
     borderBottomColor: '#ddd'
   },

--- a/app/screens/IOSMoreScreen.js
+++ b/app/screens/IOSMoreScreen.js
@@ -1,0 +1,182 @@
+import React from 'react'
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  ScrollView
+} from 'react-native'
+import Screen from './Screen'
+import Header from '../components/Header'
+import Icon from 'react-native-vector-icons/Ionicons'
+import Package from '../../package'
+import User from '../db/User'
+import Colors from '../helpers/Colors'
+
+export default class IOSMoreScreen extends Screen {
+  constructor(props) {
+    super(props)
+  }
+
+  renderLoggedInMenu() {
+    return (
+      <View>
+        <TouchableOpacity
+          onPress={() => {
+            this.navigator.navigate('Account')
+          }}
+          style={[styles.formItem]}>
+          <Text style={styles.formLabel}>
+            Account Settings
+          </Text>
+          <Icon name={'ios-arrow-forward'} size={22} color={'#777'}/>
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={() => User.logout()}
+          style={[styles.formItem, styles.lastFormItem]}>
+          <Text style={[styles.formLabel, {color: Colors.danger}]}>
+            Logout
+          </Text>
+          <Icon name={'ios-log-out'} size={22} color={Colors.danger}/>
+        </TouchableOpacity>
+      </View>
+    )
+  }
+
+  renderLoggedOutMenu() {
+    return (
+      <View>
+        <TouchableOpacity
+          onPress={() => {
+            this.navigator.navigate('Register')
+          }}
+          style={[styles.formItem]}>
+          <Text style={styles.formLabel}>
+            Register
+          </Text>
+          <Icon name={'ios-arrow-forward'} size={22} color={'#777'}/>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          onPress={() => {
+            this.navigator.navigate('Login')
+          }}
+          style={[styles.formItem, styles.lastFormItem]}>
+          <Text style={styles.formLabel}>
+            Log In
+          </Text>
+          <Icon name={'ios-arrow-forward'} size={22} color={'#777'}/>
+        </TouchableOpacity>
+      </View>
+    )
+  }
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <Header title={'More'}
+                elevation={2}
+                navigator={this.navigator}
+                showLeftIcon={false}
+                showRightIcon={false}/>
+        <ScrollView style={styles.body}>
+          <Text style={styles.title}>Membership</Text>
+          <View style={styles.card}>
+            {User.loggedIn() ? this.renderLoggedInMenu() : this.renderLoggedOutMenu()}
+          </View>
+
+          <Text style={styles.title}>Information</Text>
+          <View style={styles.card}>
+            <View
+              style={[styles.formItem]}>
+              <Text style={[styles.formLabel, {marginRight: 10}]}>
+                App Version
+              </Text>
+              <Text style={[styles.formLabel, {fontWeight: 'normal'}]}>{Package.version}</Text>
+            </View>
+            <TouchableOpacity
+              onPress={() => {
+                this.navigator.navigate('About')
+              }}
+              style={styles.formItem}>
+              <Text style={styles.formLabel}>
+                About Us
+              </Text>
+              <Icon name={'ios-arrow-forward'} size={22} color={'#777'}/>
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={() => {
+                this.navigator.navigate('PrivacyPolicy')
+              }}
+              style={styles.formItem}>
+              <Text style={styles.formLabel}>
+                Privacy Policy
+              </Text>
+              <Icon name={'ios-arrow-forward'} size={22} color={'#777'}/>
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={() => {
+                this.navigator.navigate('HealthSafety')
+              }}
+              style={[styles.formItem, styles.lastFormItem]}>
+              <Text style={styles.formLabel}>
+                Health and Safety
+              </Text>
+              <Icon name={'ios-arrow-forward'} size={22} color={'#777'}/>
+            </TouchableOpacity>
+          </View>
+        </ScrollView>
+      </View>
+    )
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1
+  },
+
+  body: {
+    flex           : 1,
+    backgroundColor: '#f7f7f7',
+    paddingTop     : 10
+  },
+
+  title: {
+    fontSize         : 14,
+    color            : '#222',
+    paddingHorizontal: 5,
+    fontWeight       : 'bold',
+    marginTop        : 10
+  },
+
+  card: {
+    backgroundColor  : '#fff',
+    borderTopWidth   : 1,
+    borderTopColor   : '#ddd',
+    borderBottomWidth: 1,
+    borderBottomColor: '#ddd',
+    paddingHorizontal: 5,
+    marginTop        : 5,
+    marginBottom     : 10
+  },
+
+  formItem: {
+    paddingRight     : 10,
+    flexDirection    : 'row',
+    alignItems       : 'center',
+    justifyContent   : 'space-between',
+    height           : 40,
+    borderBottomWidth: 1,
+    borderBottomColor: '#ddd'
+  },
+
+  lastFormItem: {
+    borderBottomWidth: 0
+  },
+
+  formLabel: {
+    fontSize: 14,
+    color   : '#222'
+  }
+})

--- a/app/screens/LoginScreen.js
+++ b/app/screens/LoginScreen.js
@@ -8,7 +8,8 @@ import {
   TextInput,
   Text,
   TouchableOpacity,
-  BackHandler
+  BackHandler,
+  Platform
 } from 'react-native'
 import Header from '../components/Header'
 import Elevation from '../helpers/Elevation'
@@ -19,6 +20,8 @@ import Spinner from '../components/Spinner'
 import AText from '../components/Atext'
 import User from '../db/User'
 import Errors from '../helpers/Errors'
+
+const isAndroid = Platform.OS === 'android'
 
 export default class LoginScreen extends Screen {
   static navigationOptions = {
@@ -140,7 +143,7 @@ export default class LoginScreen extends Screen {
         <Header title="Login"
                 navigator={this.navigator}
                 showRightIcon={false}
-                initial={true}
+                initial={isAndroid}
                 onMenuPress={() => this.navigator.toggleDrawer()}/>
         <ScrollView keyboardDismissMode={'on-drag'}
                     showsVerticalScrollIndicator={false}

--- a/app/screens/ObservationScreen.js
+++ b/app/screens/ObservationScreen.js
@@ -449,7 +449,7 @@ export default class ObservationScreen extends Screen {
    */
   _renderShareButton() {
     const observation = this.state.entry
-    if (!observation.synced && observation.needs_update) {
+    if (!observation.synced || observation.needs_update) {
       return null
     }
 

--- a/app/screens/PrivacyPolicySreen.js
+++ b/app/screens/PrivacyPolicySreen.js
@@ -6,10 +6,13 @@ import {
   ScrollView,
   StyleSheet,
   Text,
-  BackHandler
+  BackHandler,
+  Platform
 } from 'react-native'
 import Header from '../components/Header'
 import Elevation from '../helpers/Elevation'
+
+const isAndroid = Platform.OS === 'android'
 
 export default class PrivacyPolicyScreen extends Screen {
   static navigationOptions = {
@@ -33,7 +36,7 @@ export default class PrivacyPolicyScreen extends Screen {
           navigator={this.navigator}
           elevation={2}
           showRightIcon={false}
-          initial={true}
+          initial={isAndroid}
           onMenuPress={() => this.navigator.toggleDrawer()}
         />
         <ScrollView style={styles.scrollView}>

--- a/app/screens/RegisterationScreen.js
+++ b/app/screens/RegisterationScreen.js
@@ -6,7 +6,6 @@ import {
   StyleSheet,
   TextInput,
   Text,
-  DeviceEventEmitter,
   Platform,
   TouchableOpacity,
   BackHandler
@@ -207,7 +206,7 @@ export default class RegistrationScreen extends Screen {
         <Header title="Register"
                 navigator={this.navigator}
                 showRightIcon={false}
-                initial={true}
+                initial={isAndroid}
                 onMenuPress={() => this.navigator.toggleDrawer()}/>
         <KeyboardAwareScrollView
           keyboardDismissMode={isAndroid ? 'none' : 'on-drag'}

--- a/app/screens/SubmittedScreen.js
+++ b/app/screens/SubmittedScreen.js
@@ -262,7 +262,7 @@ export default class SubmittedScreen extends Screen {
             </View>
             : null}
 
-          <View style={[styles.card, {marginBottom: observation.name === 'American Chestnut' ? 0 : undefined}]}>
+          <View style={[styles.card, {marginBottom: observation.name === 'American Chestnut' ? 10 : undefined}]}>
             {this.renderMap(observation)}
             <Text style={styles.title}>
               {observation.name === 'Other' ? `${observation.name} (${data.otherLabel})` : observation.name}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7495,7 +7495,7 @@
       }
     },
     "react-native-camera": {
-      "version": "github:react-native-community/react-native-camera#cb62502a47c1b00a251a1aade2f6f3321c4e8988",
+      "version": "github:react-native-community/react-native-camera#236758147d558b67f0caef808325985edcd2f633",
       "from": "github:react-native-community/react-native-camera#master",
       "requires": {
         "lodash": "^4.17.4",
@@ -7841,9 +7841,9 @@
       }
     },
     "realm": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/realm/-/realm-2.11.0.tgz",
-      "integrity": "sha1-ZB///6mf++kwbG7GSVHkwf94AZA=",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/realm/-/realm-2.10.0.tgz",
+      "integrity": "sha1-vbuvODPZg4wqmSi2y5Y1Q+ABXqk=",
       "requires": {
         "command-line-args": "^4.0.6",
         "decompress": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "react-native-tab-view": "0.0.65",
     "react-native-vector-icons": "^4.6.0",
     "react-navigation": "2.0.4",
-    "realm": "^2.11.0",
+    "realm": "2.10.0",
     "tcomb": "^3.2.25",
     "tcomb-validation": "^3.4.1"
   },


### PR DESCRIPTION
Fix issue where iOS crashes when moving from observations to home. This fix reimplements navigation for iOS to follow the most common practices for iOS devices.

The PR makes the following changes:
- Separates navigation for iOS from Android
- Removes the sidebar completely on iOS
- Adds a `more` tab button on iOS to display everything that used to go to the sidebar.
- Follows [Apple's Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/ios/bars/tab-bars/) to the best of our ability