### PR TITLE
Editing an other tree observation now displays user-defined types in search

### DIFF
--- a/app/components/AutoComplete.js
+++ b/app/components/AutoComplete.js
@@ -12,7 +12,6 @@ import {
   Platform,
   Keyboard
 } from 'react-native'
-import TreeNames from '../resources/TreeLatinNames.js'
 import Colors from '../helpers/Colors'
 import Elevation from '../helpers/Elevation'
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
@@ -22,16 +21,20 @@ export default class AutoComplete extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      resultList            : TreeNames,
-      selected              : null,
+      resultList            : {},
+      selected              : 'test test', // this.props.defaultText, // ? this.props.defaultText : null,
       modalVisible          : false,
-      searchText            : '',
+      searchText            : 'test test', // this.props.defaultText, // ? this.props.defaultText : '',
       textFieldBottomSpacing: 0
     }
 
     this.events = []
     this.events.push(Keyboard.addListener('keyboardDidShow', () => this.setBottomSpacing(true)))
     this.events.push(Keyboard.addListener('keyboardDidHide', () => this.setBottomSpacing(false)))
+  }
+
+  componentDidMount() {
+
   }
 
   /**
@@ -47,9 +50,6 @@ export default class AutoComplete extends Component {
    */
   open = () => {
     this.setState({
-      resultList  : this.props.defaultList,
-      searchText  : '',
-      selected    : null,
       modalVisible: true
     })
   }
@@ -128,7 +128,7 @@ export default class AutoComplete extends Component {
 
     let matches = {}
 
-    for (const [species, common] of Object.entries(TreeNames)) {
+    for (const [species, common] of Object.entries(this.props.defaultList)) {
       if (species.toLowerCase().trim().indexOf(text) > -1) {
         matches[species] = common.join(', ')
         continue
@@ -193,9 +193,10 @@ export default class AutoComplete extends Component {
                   style={[styles.textField]}
                   placeholder={'Search or create your own label'}
                   placeholderTextColor="#aaa"
-                  onChangeText={searchText => {
-                    this.setState({searchText})
-                    this.search(searchText)
+                  onChangeText={text => {
+                    this.setState({searchText: text})
+                    this.setState({selected: text})
+                    this.search(text)
                   }}
                   value={this.state.selected}
                   underlineColorAndroid="transparent"

--- a/app/components/AutoComplete.js
+++ b/app/components/AutoComplete.js
@@ -47,7 +47,7 @@ export default class AutoComplete extends Component {
    */
   open = () => {
     this.setState({
-      resultList  : TreeNames,
+      resultList  : this.props.defaultList,
       searchText  : '',
       selected    : null,
       modalVisible: true
@@ -122,7 +122,7 @@ export default class AutoComplete extends Component {
 
     // return to the default search case
     if (!text) {
-      this.setState({resultList: TreeNames})
+      this.setState({resultList: this.props.defaultList})
       return
     }
 

--- a/app/components/Form.js
+++ b/app/components/Form.js
@@ -37,6 +37,7 @@ import AdvancedSettingsModal from './AdvancedSettingsModal'
 import CustomIDModal from './CustomIDModal'
 import User from '../db/User'
 import Images from '../helpers/Images'
+import TreeNames from '../resources/TreeLatinNames.js'
 
 const isAndroid  = Platform.OS === 'android'
 const Coordinate = t.refinement(t.Number, (n) => n !== 0, 'Coordinate')
@@ -587,6 +588,10 @@ export default class Form extends Component {
 
     if (DCP[key].modalFreeText) {
       let value = this.getMultiCheckValue(this.state.metadata[key], DCP[key].multiCheck)
+      let defaultList = TreeNames;
+      if (this.state.metadata[key] && !(key in TreeNames)) {
+        defaultList[this.state.metadata[key]] = [this.state.metadata[key]]
+      }
       return (
         <AutoComplete
           style={styles.picker}
@@ -594,6 +599,7 @@ export default class Form extends Component {
             this.setState({metadata: {...this.state.metadata, [key]: option}})
           }}
           key={key}
+          defaultList={defaultList}
         >
           <View style={styles.formGroup}>
             <View style={styles.picker}>

--- a/app/components/Form.js
+++ b/app/components/Form.js
@@ -600,6 +600,7 @@ export default class Form extends Component {
           }}
           key={key}
           defaultList={defaultList}
+          defaultText={this.state.metadata[key]}
         >
           <View style={styles.formGroup}>
             <View style={styles.picker}>


### PR DESCRIPTION
#609 

i created a new other tree observation with a new type called 'big tree'

![image](https://user-images.githubusercontent.com/32902460/62230852-ba134b80-b390-11e9-8c67-2e9db216bc7a.png)

after editing the tree species of this observation and searching for 'big tree', it shows up in the search box

![image](https://user-images.githubusercontent.com/32902460/62230938-f646ac00-b390-11e9-9bd0-b58030c6e7cb.png)

i was then able to select the option for the new tree and proceed to upload the observation without any problem